### PR TITLE
Zeroize CState from Setup1 to avoid possible data race

### DIFF
--- a/firmware.ino
+++ b/firmware.ino
@@ -22,6 +22,7 @@ void loop() {
 }
 
 void setup1() {
+  ZeroizeCState();
   WireSetup(GIZMO_HW_I2C_SDA, GIZMO_HW_I2C_SCL);
 }
 

--- a/gizmo.cpp
+++ b/gizmo.cpp
@@ -79,7 +79,7 @@ bool loadConfig(String);
 void loadConfigFromSerial();
 void checkIfShouldConfig();
 void checkBatteryArchitecture();
-void zeroizeCState();
+void ZeroizeCState();
 
 bool netLinkOk();
 void netLinkResetWiznet();
@@ -126,7 +126,7 @@ void ConfigureWiznetReset(byte rst) {
 }
 
 
-void zeroizeCState() {
+void ZeroizeCState() {
   cstate.Button0 = false;
   cstate.Button1 = false;
   cstate.Button2 = false;
@@ -152,7 +152,7 @@ void GizmoSetup() {
   // Ensure that the cstate values for axis data start at a reasonable
   // zero point.  This prevents machines from running off into the
   // wild blue yonder.
-  zeroizeCState();
+  ZeroizeCState();
 
   delay(3000);
 
@@ -554,7 +554,7 @@ void netStateRun() {
 
   if (nextControlPacketDueBy < millis()) {
     status.SetControlConnected(false);
-    zeroizeCState();
+    ZeroizeCState();
     return;
   }
 

--- a/gizmo.h
+++ b/gizmo.h
@@ -74,6 +74,7 @@ enum NetLink {
   NET_WIRELESS,
 };
 
+void ZeroizeCState();
 void ConfigureTeamNumber(int);
 void ConfigureStatusIO(byte, byte, byte, byte, byte, byte, byte, byte);
 void ConfigureBoardVoltageTuning(float, float);


### PR DESCRIPTION
I don't know why I was originally thinking to hold the user processor in reset.  In retrospect the data race is painfully obvious since `setup()` runs through a ton of hardware initialization including reading from the flash, whereas `setup1()` registers a callback and that's it.  This ensures that no matter which core comes up faster the CState structure has been zeroed out.

Resolves #5 . 